### PR TITLE
add mysql-5.7-original

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
  * elasticsearch 5 (6, 2)
  * freetds 0.91
- * mariadb 10.2 (10.3, 10.1, 10.0, 10.0-original)
+ * mariadb 10.2 (10.3, 10.1, 10.0, 10.0-original, or mysql: 5.7-original)
  * memcached 1.4
  * mongodb 3.4
  * nodejs 8 (9, 7, 6, 5, 4, 4-original)

--- a/ansible/playbook.yml
+++ b/ansible/playbook.yml
@@ -9,6 +9,7 @@
     - { role: elasticsearch-6, when: role.elasticsearch and elasticsearch.version == 6}
     - { role: freetds, when: role.freetds }
     - git
+    - { role: mysql-5.7-original, when: role.mariadb and mariadb.version == '5.7-original' }
     - { role: mariadb-10.0-original, when: role.mariadb and mariadb.version == '10.0-original' }
     - { role: mariadb-10.0, when: role.mariadb and mariadb.version == 10.0 }
     - { role: mariadb-10.1, when: role.mariadb and mariadb.version == 10.1 }

--- a/ansible/roles/mysql-5.7-original/handlers/main.yml
+++ b/ansible/roles/mysql-5.7-original/handlers/main.yml
@@ -1,0 +1,3 @@
+---
+- name: restart mysql
+  service: name=mysql state=restarted

--- a/ansible/roles/mysql-5.7-original/tasks/main.yml
+++ b/ansible/roles/mysql-5.7-original/tasks/main.yml
@@ -1,0 +1,36 @@
+---
+- name: install
+  apt: name={{ item }} state=present
+  with_items:
+    - mysql-server
+    - mysql-client
+    - python-mysqldb
+
+- name: configure my.cnf
+  template:
+    src=my.cnf.j2
+    dest=/etc/mysql/my.cnf
+  notify:
+      - restart mysql
+
+- name: wait for mysql
+  wait_for: port={{mariadb.config.mysqld.port}}
+
+- name: change default user to {{ mariadb.username }} / {{ mariadb.password }}
+  mysql_user: name={{ mariadb.username }} password={{ mariadb.password }} check_implicit_admin=true
+
+- name: copy .my.cnf file for user root
+  template:
+    src=user-my.cnf.j2
+    dest=/root/.my.cnf
+    owner=root
+    group=root
+    mode=0600
+
+- name: copy .my.cnf for user vagrant
+  template:
+    src=user-my.cnf.j2
+    dest=/home/vagrant/.my.cnf
+    owner=vagrant
+    group=vagrant
+    mode=0600

--- a/ansible/roles/mysql-5.7-original/templates/my.cnf.j2
+++ b/ansible/roles/mysql-5.7-original/templates/my.cnf.j2
@@ -1,0 +1,7 @@
+{% for groupname, group in mariadb.config.iteritems() %}
+[{{ groupname }}]
+{% for option, value in group.iteritems() %}
+{{ option }} = {{ value }}
+{% endfor %}
+
+{% endfor %}

--- a/ansible/roles/mysql-5.7-original/templates/user-my.cnf.j2
+++ b/ansible/roles/mysql-5.7-original/templates/user-my.cnf.j2
@@ -1,0 +1,3 @@
+[client]
+user={{ mariadb.username }}
+password={{ mariadb.password }}


### PR DESCRIPTION
I run into problems as mariadb using aria storage engine for its internally created temporary tables. Thus I needed to switch to original mysql.