### PR TITLE
adding erlang repo from bintray to meet rabbitmq dependency

### DIFF
--- a/ansible/roles/rabbitmq/tasks/main.yml
+++ b/ansible/roles/rabbitmq/tasks/main.yml
@@ -4,6 +4,10 @@
 
 - name: add repository
   apt_repository:
+    repo: "deb https://dl.bintray.com/rabbitmq-erlang/debian bionic erlang"
+
+- name: add repository
+  apt_repository:
     repo: "deb https://dl.bintray.com/rabbitmq/debian bionic rabbitmq-server-v{{ rabbitmq.version }}.x"
 
 - name: install


### PR DESCRIPTION
fixes an error during provisioning that wrong erlang dependencies are available (ubuntu ones instead of bintray ones).