### PR TITLE
New box

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /ansible/playbook.retry
 /.vagrant
 /certs
+/*-cloudimg-console.log

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -64,8 +64,8 @@ Vagrant.configure(2) do |config|
 
     # Vagrant box
     # --------------------------------------------------------------------------
-    config.vm.box = 'bento/ubuntu-18.04'
-    config.vm.guest = 'ubuntu'
+    config.vm.box = setupConfig['box']
+    config.vm.guest = setupConfig['guest']
 
     # General settings
     # --------------------------------------------------------------------------

--- a/vagrant-default.yml
+++ b/vagrant-default.yml
@@ -4,6 +4,9 @@ hostname: projectname.development
 cpus: ~
 memory: 1024
 
+box: bento/ubuntu-18.04
+guest: ubuntu
+
 # network: -------------------------------------------------------------------------------------------------------------
 
 network:

--- a/vagrant-default.yml
+++ b/vagrant-default.yml
@@ -4,7 +4,7 @@ hostname: projectname.development
 cpus: ~
 memory: 1024
 
-box: bento/ubuntu-18.04
+box: ubuntu/bionic64
 guest: ubuntu
 
 # network: -------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
As a follow up for https://github.com/vagrant-php/ubuntu/pull/55 I suggest to move the default box to the one provided by ubuntu itself. Mainly because the box from bento is very slowly being updated (if ever?).

Edit: If you're good with switching the default box you can merge this one and close https://github.com/vagrant-php/ubuntu/pull/55.

Edit2: Compared the filesize the new box is smaller too:
- 479M	bento-VAGRANTSLASH-ubuntu-18.04/201812.27.0/virtualbox
- 306M	ubuntu-VAGRANTSLASH-bionic64/20190801.1.0/virtualbox