### PR TITLE
Fixing nginx templates reusability

### DIFF
--- a/ansible/roles/nginx/templates/nginx.conf.j2
+++ b/ansible/roles/nginx/templates/nginx.conf.j2
@@ -25,7 +25,7 @@
 {% endmacro %}
 
 {% for config in nginx.server %}
-    {% set template = nginx.templates[config.template] %}
+    {% set template = nginx.templates[config.template].copy() %}
 
     {% set serverNameParts = config.server_name.split(' ') %}
 


### PR DESCRIPTION
This fixes the problem that on multiple `nginx.server` entries the template only gets the last entry corresponding to the template.